### PR TITLE
Add sub-properties to kontaktpunkt and omfang

### DIFF
--- a/applications/concept-catalogue/src/main/resources/static/ConceptRegistrationAPI.yaml
+++ b/applications/concept-catalogue/src/main/resources/static/ConceptRegistrationAPI.yaml
@@ -182,16 +182,35 @@ components:
             type: string
           bruksområde:
             type: string
-          verdiområde:
-            type: string
-            description: omfang
+          omfang:
+            $ref: "#/components/schemas/Omfang"
           kontaktpunkt:
-            type: string
+            $ref: "#/components/schemas/Kontaktpunkt"
           gyldigFom:
             type: string
             format: date
           forholdTilKilde:
             type: string
+    Omfang:
+      type: object
+      description: Også kalt verdiområde
+      properties:
+        uri:
+          type: string
+          description: Lenke til omfang
+        tekst:
+          type: string
+          description: Tekst (tittel) på omfang
+    Kontaktpunkt:
+      type: object
+      description: kontaktpunktet for dette begrepet
+      properties:
+        harEpost:
+          type: string
+          description: e-post adressen til kontaktpunkt
+        harTelefon:
+          type: string
+          description: telefonnummer til kontaktpunkt
     Virksomhet:
       type: object
       description: Ansvarlig virksomhet for begrepet [dct:publisher]


### PR DESCRIPTION
Har lagt inn endringer som løser Øyvind sine behov i slack:
> Vi har laget frontend for å gi med 'Omfang' (tittel og lenke) og 'Kontaktinformasjon' (e-post og telefon) på begrep, etter designskisser. Men vi mangler tilhørende felter i ConceptRegistrationAPI-spec. Vi har kalt dem hhv. 'omfangTittel', 'omfangLenke', 'email' og 'hasTelephone'. Legger du dette inn i spec, evt. om du vil endre navnene på noen av feltene?